### PR TITLE
Speedy changes for Java implementations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
@@ -72,49 +72,53 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
+                        <goals> <goal>compile</goal> </goals>
                         <configuration>
                             <sourceDirs>
-                                <source>src/main/kotlin</source>
-                                <source>src/main/java</source>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
-                            <args>
-                                <arg>-Xcoroutines=enable</arg>
-                            </args>
                         </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
                     <jvmTarget>1.8</jvmTarget>
+                            <experimentalCoroutines>enable</experimentalCoroutines>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
                     </execution>
                     <execution>
-                        <id>testCompile</id>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
                         <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
+                        <goals> <goal>testCompile</goal> </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -122,8 +126,17 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/src/main/java/com/example/coroutine/util/TwoDimensionArraySearchUtilsJava.java
+++ b/src/main/java/com/example/coroutine/util/TwoDimensionArraySearchUtilsJava.java
@@ -4,10 +4,16 @@ public class TwoDimensionArraySearchUtilsJava {
 
     public static int findLargestNumberInArrayRange(int startOfRange, int scanRangeSize, int[][] array) {
         int largestNumber = Integer.MIN_VALUE;
-        for (int x = startOfRange; x < (startOfRange + scanRangeSize); x++) {
-            for (int y = 0; y < array[x].length; y++) {
-                if (largestNumber < array[x][y]) {
-                    largestNumber = array[x][y];
+
+        final java.util.List<int[]> xrange = new java.util.ArrayList<>(startOfRange + scanRangeSize);
+        for (int x = startOfRange, i = 0; x < (startOfRange + scanRangeSize); x++, i++) {
+            xrange.add(array[x]);
+        }
+
+        for (int[] yrange : xrange) {
+            for (int i : yrange) {
+                if (largestNumber < i) {
+                    largestNumber = i;
                 }
             }
         }
@@ -17,6 +23,7 @@ public class TwoDimensionArraySearchUtilsJava {
 
     public static int findLargestNumberInResultArray(int[] largestNumbersInRange) {
         int largestNumber = Integer.MIN_VALUE;
+
         for (int i = 0; i < largestNumbersInRange.length; i++) {
             if (largestNumber < largestNumbersInRange[i]) {
                 largestNumber = largestNumbersInRange[i];

--- a/src/test/kotlin/com/example/coroutine/ParallelProblemsTest.kt
+++ b/src/test/kotlin/com/example/coroutine/ParallelProblemsTest.kt
@@ -1,54 +1,106 @@
 package com.example.coroutine
 
+import java.util.Arrays
 import com.example.coroutine.impl.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeAll
 import kotlin.test.assertEquals
 
 class ParallelProblemsTest {
-
-    private var largestNumberGenerated = Int.MIN_VALUE
+    private val twoDNumberArray = generate2DArray(ARRAY_SIZE)
+    private val largestNumberGenerated = largestNumber(twoDNumberArray)
 
     companion object {
         private const val ARRAY_SIZE = 30_000
-        private const val NUMBER_OF_THREADS = 2
-        private const val NUMBER_OF_COROUTINES = 2
+        private const val NUMBER_OF_THREADS = 8
+        private const val NUMBER_OF_COROUTINES = 8
+
+        @BeforeAll
+        @JvmStatic
+        internal fun beforeAll() {
+            // print2DArray(array) //DEBUG, don't run on huge array sizes
+        }
+    }
+
+
+    @Test
+    fun findTheLargestNumberInA2dArray_kotlinSerial() {
+        for (i in 1..10) {
+            System.out.print("Serial Kotlin Implementation  - test run ${i} - ")
+
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsKotlinSerialImpl())
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
     }
 
     @Test
-    fun findTheLargestNumberInA2dArray() {
-        val twoDNumberArray = generate2DArray(ARRAY_SIZE)
-        // print2DArray(array) //DEBUG, don't run on huge array sizes
+    fun findTheLargestNumberInA2dArray_kotlinMultiThread() {
+        for (i in 1..10) {
+            System.out.print("Kotlin Multi Thread Implementation - test run ${i} - ")
 
-        var startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsKotlinSerialImpl())
-        var endTime = System.currentTimeMillis()
-        System.out.println("Serial Kotlin Implementation took ${endTime - startTime}ms")
-
-        startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsKotlinMultiThreadImpl(numberOfThreads = NUMBER_OF_THREADS))
-        endTime = System.currentTimeMillis()
-        System.out.println("MultiThread Kotlin Implementation took ${endTime - startTime}ms with $NUMBER_OF_THREADS threads")
-
-        startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsKotlinCoRoutineImpl(numberOfCoRoutines = NUMBER_OF_COROUTINES))
-        endTime = System.currentTimeMillis()
-        System.out.println("CoRoutine Kotlin Implementation took ${endTime - startTime}ms with $NUMBER_OF_COROUTINES coroutines")
-
-        startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsJavaSerialImpl())
-        endTime = System.currentTimeMillis()
-        System.out.println("Serial Java Implementation took ${endTime - startTime}ms")
-
-        startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsJavaMultiThreadingImpl(NUMBER_OF_THREADS))
-        endTime = System.currentTimeMillis()
-        System.out.println("MultiThread Java Implementation took ${endTime - startTime}ms with $NUMBER_OF_THREADS threads")
-
-        startTime = System.currentTimeMillis()
-        findLargestNumberInArrayWithImplementation(twoDNumberArray, ParallelProblemsJavaCoRoutineImpl(NUMBER_OF_COROUTINES))
-        endTime = System.currentTimeMillis()
-        System.out.println("CoRoutine Java Implementation took ${endTime - startTime}ms with $NUMBER_OF_COROUTINES coroutines")
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsKotlinMultiThreadImpl(numberOfThreads = NUMBER_OF_THREADS))
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
     }
+
+    @Test
+    fun findTheLargestNumberInA2dArray_kotlinCoRoutine() {
+        for (i in 1..10) {
+            System.out.print("Serial CoRoutine Implementation - test run ${i} - ")
+
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsKotlinCoRoutineImpl(numberOfCoRoutines = NUMBER_OF_COROUTINES))
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
+    }
+
+    @Test
+    fun findTheLargestNumberInA2dArray_javaSerial() {
+        for (i in 1..10) {
+            System.out.print("Java Serial Implementation - test run ${i} - ")
+
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsJavaSerialImpl())
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
+    }
+
+    @Test
+    fun findTheLargestNumberInA2dArray_javaMultiThread() {
+        for (i in 1..10) {
+            System.out.print("Java Multi Thread Implementation - test run ${i} - ")
+
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsJavaMultiThreadingImpl(NUMBER_OF_THREADS))
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
+    }
+
+    @Test
+    fun findTheLargestNumberInA2dArray_javaCoRoutine() {
+        for (i in 1..10) {
+            System.out.print("Java CoRoutine Implementation - test run ${i} - ")
+
+            val data = Arrays.copyOf(twoDNumberArray, ARRAY_SIZE)
+            val startTime = System.currentTimeMillis()
+            findLargestNumberInArrayWithImplementation(data, ParallelProblemsJavaCoRoutineImpl(NUMBER_OF_COROUTINES))
+            val endTime = System.currentTimeMillis()
+            System.out.println("${endTime - startTime}ms")
+        }
+    }
+
 
     private fun generate2DArray(size: Int): Array<IntArray> {
         val twoDNumberArray = Array(size) { IntArray(size) }
@@ -56,6 +108,17 @@ class ParallelProblemsTest {
         for (x in twoDNumberArray.indices) {
             for (y in twoDNumberArray.indices) {
                 twoDNumberArray[x][y] = (Int.MIN_VALUE..Int.MAX_VALUE).random()
+            }
+        }
+
+        return twoDNumberArray
+    }
+
+    private fun largestNumber(twoDNumberArray: Array<IntArray>): Int {
+        var largestNumberGenerated = Int.MIN_VALUE
+
+        for (x in twoDNumberArray.indices) {
+            for (y in twoDNumberArray.indices) {
                 if (largestNumberGenerated < twoDNumberArray[x][y]) {
                     largestNumberGenerated = twoDNumberArray[x][y]
                 }
@@ -64,7 +127,7 @@ class ParallelProblemsTest {
 
         System.out.println("Largest number generated was $largestNumberGenerated")
 
-        return twoDNumberArray
+        return largestNumberGenerated
     }
 
     private fun findLargestNumberInArrayWithImplementation(twoDNumberArray: Array<IntArray>, parallelProblems: ParallelProblems) {


### PR DESCRIPTION
This change refactors a couple areas in the Java implementations:

* For `TwoDimensionArraySearchUtilsJava`, the nested `for` loops
  were refactored into 2 separate sequential loops. This tries to cancel
  the impact of memory pre-fetching whereby multiple concurrent threads
  may start clobbering each other's working data in the shared caches.
  In this implementation, references to each second dimension are held
  as references in a local array, which are then accessed by ref instead
  of as `[x*y]`. This reduced computation by about 50%.

* `ParallelProblemsJavaMultiThreadingImpl` now behaves more like a
  map-reduce algorithm where the task of _finding_ the largest number in
  a slice of the array. Upon completion of all threads, the results are
  reduced by the calling thread, returning the maximum result.

* `ParallelProblemsTest` has been refactored to ensure that each test
  has an equally fair advantage of being optimized by the JVM. Before,
  when all tests were run sequentially, the JVM's optimization path may
  have been hindered due to the method size and the inability to
  identify which paths where hot. In this implementation, the same
  branch of code is executed 10 times sequentially, giving the VM a
  better chance at optimizing.

* The maven module has been changed to work properly with `mvn` with no
  other tools or IDEs.